### PR TITLE
Formatting tweaks and small refactorings

### DIFF
--- a/template/Mail.php
+++ b/template/Mail.php
@@ -12,6 +12,7 @@ use lithium\core\Libraries;
  * @see lithium\template\View
  */
 class Mail extends \lithium\template\View {
+
 	/**
 	 * Holds a reference to the `Message` object that will be delivered. Allows headers
 	 * and other message attributes to be assigned in the templating layer.

--- a/tests/cases/action/MailerTest.php
+++ b/tests/cases/action/MailerTest.php
@@ -16,6 +16,7 @@ Mailer::applyFilter('deliver', $filter);
 TestMailer::applyFilter('deliver', $filter);
 
 class MailerTest extends \lithium\test\Unit {
+
 	public function testCreateMessage() {
 		$to = 'foo@bar';
 		$message = Mailer::message(compact('to'));
@@ -41,7 +42,7 @@ class MailerTest extends \lithium\test\Unit {
 		$this->assertEqual('fake rendered message', $message->body('html'));
 		$this->assertEqual('fake rendered message', $message->body('text'));
 		$this->assertFalse(is_null($transport));
-		$this->assertEqual(array('extra' => 'data'), $transport_options);
+		$this->assertEqual(array('extra' => 'data'), $transportOptions);
 	}
 
 	public function testSetsMailer() {

--- a/tests/cases/net/mail/DeliveryTest.php
+++ b/tests/cases/net/mail/DeliveryTest.php
@@ -6,6 +6,7 @@ use li3_mailer\tests\mocks\net\mail\DeliveryWithPath;
 use li3_mailer\net\mail\Transport;
 
 class DeliveryTest extends \lithium\test\Unit {
+
 	public function testUsesGoodAdapters() {
 		$params = array(array('adapter' => 'Simple'), DeliveryWithPath::_adaptersPath());
 		$class = DeliveryWithPath::invokeMethod('_class', $params);

--- a/tests/cases/net/mail/GrammarTest.php
+++ b/tests/cases/net/mail/GrammarTest.php
@@ -5,6 +5,7 @@ namespace li3_mailer\tests\cases\net\mail;
 use li3_mailer\net\mail\Grammar;
 
 class GrammarTest extends \lithium\test\Unit {
+
 	public function testToken() {
 		$grammar = array('foo' => 'bar', 'baz' => 'qux');
 		$g = new Grammar(compact('grammar'));

--- a/tests/cases/net/mail/MediaTest.php
+++ b/tests/cases/net/mail/MediaTest.php
@@ -8,6 +8,7 @@ use li3_mailer\tests\mocks\template\Mail;
 use lithium\core\Libraries;
 
 class MediaTest extends \lithium\test\Unit {
+
 	public function testType() {
 		$this->assertEqual('text/plain', Media::type('text'));
 		$this->assertEqual('text/html', Media::type('html'));
@@ -89,10 +90,12 @@ class MediaTest extends \lithium\test\Unit {
 		$this->assertTrue($view instanceof Mail);
 		$loader = $view->loader();
 		$template = $loader->template('template', $options);
-		$this->assertEqual(array(
+
+		$expected = array(
 			LITHIUM_APP_PATH . '/mails/bar/foo.text.php',
 			LITHIUM_APP_PATH . '/mails/foo.text.php'
-		), $template);
+		);
+		$this->assertEqual($expected, $template);
 
 		Media::type('foo', false);
 	}
@@ -128,18 +131,17 @@ class MediaTest extends \lithium\test\Unit {
 			'https://foo.local' => array('HTTP_HOST' => 'foo.local', 'HTTPS' => true),
 			'http://foo.local/base' => array('HTTP_HOST' => 'foo.local', 'base' => '/base')
 		);
+
 		foreach ($tests as $base_url => $expect) {
 			$message = new Message(compact('base_url'));
 			$request = Media::invokeMethod('_request', array($message));
 			$expect += array('HTTPS' => false, 'base' => '');
+
 			foreach ($expect as $key => $expected) {
 				$result = $request->env($key);
-				$this->assertEqual(
-					$expected,
-					$result,
-					"`{$key}` failed for {$base_url} ({$message->base_url}),"
-					. " expected: `{$expected}`, result: `{$result}`"
-				);
+				$msg = "`{$key}` failed for {$base_url} ({$message->base_url}),";
+				$msg .= " expected: `{$expected}`, result: `{$result}`";
+				$this->assertEqual($expected, $result, $msg);
 			}
 		}
 	}

--- a/tests/cases/net/mail/MessageTest.php
+++ b/tests/cases/net/mail/MessageTest.php
@@ -5,13 +5,15 @@ namespace li3_mailer\tests\cases\net\mail;
 use li3_mailer\net\mail\Message;
 
 class MessageTest extends \lithium\test\Unit {
+
 	public function testConstruct() {
-		$config = array('subject', 'date', 'return_path', 'sender', 'from', 'reply_to',
-				'to', 'cc', 'bcc', 'types', 'charset', 'headers', 'body');
-		$config = array_combine($config, array_map(function($name) {
-			return "test {$name}";
-		}, $config));
+		$config = array(
+			'subject', 'date', 'return_path', 'sender', 'from', 'reply_to', 'to',
+			'cc', 'bcc', 'types', 'charset', 'headers', 'body'
+		);
+		$config = array_combine($config, array_map(function($n) { return "test {$n}"; }, $config));
 		$message = new Message($config);
+
 		foreach ($config as $prop => $expected) {
 			$this->assertEqual($expected, $message->$prop);
 		}

--- a/tests/mocks/net/mail/Delivery.php
+++ b/tests/mocks/net/mail/Delivery.php
@@ -5,6 +5,7 @@ namespace li3_mailer\tests\mocks\net\mail;
 use li3_mailer\tests\mocks\net\mail\Transport;
 
 class Delivery extends \li3_mailer\net\mail\Delivery {
+
 	protected static $_configurations = array('test' => array('from' => 'adapter@config'));
 
 	public static function adapter($name = null) {

--- a/tests/mocks/net/mail/DeliveryWithPath.php
+++ b/tests/mocks/net/mail/DeliveryWithPath.php
@@ -3,6 +3,7 @@
 namespace li3_mailer\tests\mocks\net\mail;
 
 class DeliveryWithPath extends \li3_mailer\net\mail\Delivery {
+
 	public static function _adaptersPath() {
 		return static::$_adapters;
 	}

--- a/tests/mocks/net/mail/Transport.php
+++ b/tests/mocks/net/mail/Transport.php
@@ -3,6 +3,7 @@
 namespace li3_mailer\tests\mocks\net\mail;
 
 class Transport extends \li3_mailer\net\mail\Transport {
+
 	public function deliver($message, array $options = array()) {
 		return true;
 	}

--- a/tests/mocks/net/mail/transport/adapter/Swift.php
+++ b/tests/mocks/net/mail/transport/adapter/Swift.php
@@ -5,6 +5,7 @@ namespace li3_mailer\tests\mocks\net\mail\transport\adapter;
 use li3_mailer\tests\mocks\net\mail\transport\adapter\SwiftTransport;
 
 class Swift extends \li3_mailer\net\mail\transport\adapter\Swift {
+
 	protected function transport(array $options = array()) {
 		return new SwiftTransport();
 	}

--- a/tests/mocks/net/mail/transport/adapter/SwiftTransport.php
+++ b/tests/mocks/net/mail/transport/adapter/SwiftTransport.php
@@ -3,6 +3,7 @@
 namespace li3_mailer\tests\mocks\net\mail\transport\adapter;
 
 class SwiftTransport {
+
 	public $delivered = array();
 
 	public function send($message) {

--- a/tests/mocks/template/Mail.php
+++ b/tests/mocks/template/Mail.php
@@ -5,6 +5,7 @@ namespace li3_mailer\tests\mocks\template;
 use li3_mailer\tests\mocks\template\mail\adapter\FileLoader;
 
 class Mail extends \li3_mailer\template\Mail {
+
 	public function renderer() {
 		return $this->_renderer;
 	}

--- a/tests/mocks/template/MailWithoutRender.php
+++ b/tests/mocks/template/MailWithoutRender.php
@@ -3,6 +3,7 @@
 namespace li3_mailer\tests\mocks\template;
 
 class MailWithoutRender extends \li3_mailer\template\Mail {
+
 	public function render($process, array $data = array(), array $options = array()) {
 		return compact('process', 'data', 'options');
 	}

--- a/tests/mocks/template/mail/Compiler.php
+++ b/tests/mocks/template/mail/Compiler.php
@@ -3,6 +3,7 @@
 namespace li3_mailer\tests\mocks\template\mail;
 
 class Compiler extends \li3_mailer\template\mail\Compiler {
+
 	public function renderer() {
 		return $this->_renderer;
 	}

--- a/tests/mocks/template/mail/adapter/FileLoader.php
+++ b/tests/mocks/template/mail/adapter/FileLoader.php
@@ -6,6 +6,7 @@ use lithium\util\String;
 use lithium\template\TemplateException;
 
 class FileLoader extends \lithium\template\view\adapter\File {
+
 	protected function _paths($type, array $params) {
 		if (!isset($this->_paths[$type])) {
 			throw new TemplateException("Invalid template type '{$type}'.");


### PR DESCRIPTION
I made some coding-standards-related formatting tweaks, as well as simplified a couple of conditional blocks. Also, I noticed in `li3_mailer\template\Mail::_init()`, you're calling `Object::_init()` directly. If I moved the `Libraries::locate()` lookup path in `View::_init()` to a property, would you be able to eliminate that method?
