### PR TITLE
Working Mailgun transport adapter

### DIFF
--- a/net/mail/Transport.php
+++ b/net/mail/Transport.php
@@ -9,6 +9,7 @@ namespace li3_mailer\net\mail;
  * @see li3_mailer\net\mail\transport\adapter\Simple
  * @see li3_mailer\net\mail\transport\adapter\Debug
  * @see li3_mailer\net\mail\transport\adapter\Swift
+ * @see li3_mailer\net\mail\transport\adapter\Mailgun
  */
 abstract class Transport extends \lithium\core\Object {
 	/**

--- a/net/mail/transport/adapter/Mailgun.php
+++ b/net/mail/transport/adapter/Mailgun.php
@@ -143,6 +143,15 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 		if(isset($message->campaign)){
 			$data['o:campaign'] = $message->campaign;
 		}
+		//TAGS is always an array
+		if(isset($message->tags) && is_array($message->tags) && count($message->tags)){
+			$i = 1;
+			foreach($message->tags as $tag){
+				$data["o:tag[$i]"] = $tag;
+				$i++;
+			}
+		}
+		
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
 		curl_exec($ch);
 		curl_close($ch);

--- a/net/mail/transport/adapter/Mailgun.php
+++ b/net/mail/transport/adapter/Mailgun.php
@@ -151,6 +151,10 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 			}
 		}
 		
+		if(isset($message->testmode)){
+			$data['o:testmode'] = $message->testmode;
+		}
+		
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
 		curl_exec($ch);
 		curl_close($ch);

--- a/net/mail/transport/adapter/Mailgun.php
+++ b/net/mail/transport/adapter/Mailgun.php
@@ -159,5 +159,6 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 		curl_exec($ch);
 		curl_close($ch);
 	}
+}
 
 ?>

--- a/net/mail/transport/adapter/Mailgun.php
+++ b/net/mail/transport/adapter/Mailgun.php
@@ -47,6 +47,7 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 	 * @return mixed The return value of the `deliver` function.
 	 */
 	public function deliver($message, array $options = array()) {
+		//$this->debug($message);
 		$config = $this->_config;
 		$headers = $message->headers;
 		foreach ($this->_message_addresses as $property => $header) {
@@ -127,8 +128,8 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 			'to' => $to,
 			//'o:campaign' => '860s', // ADD THIS FOR A CAMPAIGN
 			'subject' => $message->subject,
-			//'text' => $body, // USE THIS FOR TEXT ONLY EMAIL
-			'html' => $body // USE THIS FOR HTML EMAIL
+			'text' => $message->body('text'), // USE THIS FOR TEXT ONLY EMAIL
+			'html' => $message->body('html') // USE THIS FOR HTML EMAIL
 		);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
 		curl_exec($ch);

--- a/net/mail/transport/adapter/Mailgun.php
+++ b/net/mail/transport/adapter/Mailgun.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace li3_mailer\net\mail\transport\adapter;
+
+use RuntimeException;
+
+/**
+ * The `Mailgun` adapter sends email through Mailgun's REST API. 
+ * _NOTE: This transport requires an API account (and associated 
+ * key) from Mailgun, as well as the `curl` extension for PHP._
+ *
+ * An example configuration:
+ * {{{Delivery::config(array('simple' => array(
+ *     'adapter' => 'Mailgun',
+ *     'from' => 'my@address',
+ *     'key' => 'mysecretkey'
+ * )));}}}
+ * Additional methods specific to Mailgun are included but not 
+ * mandatory for sending messages.
+ *
+ * @see http://php.net/curl
+ * @see li3_mailer\net\mail\Delivery
+ * @see li3_mailer\net\mail\transport\adapter\Mailgun::deliver()
+ * @see http://documentation.mailgun.net
+ */
+class Mailgun extends \li3_mailer\net\mail\Transport {
+	/**
+	 * Message property names for translating a `li3_mailer\net\mail\Message`
+	 * properties to headers (these properties are addresses).
+	 *
+	 * @see li3_mailer\net\mail\transport\adapter\Simple::deliver()
+	 * @see li3_mailer\net\mail\Message
+	 * @var array
+	 */
+	protected $_message_addresses = array(
+		'return_path' => 'Return-Path', 'sender', 'from',
+		'reply_to' => 'Reply-To', 'to', 'cc', 'bcc'
+	);
+
+	/**
+	 * Deliver a message with Mailgun's REST API via curl.
+	 *
+	 * @see http://php.net/curl
+	 * @see http://documentation.mailgun.net/quickstart.html#sending-messages
+	 * @param object $message The message to deliver.
+	 * @param array $options Additional Mailgun-specific options supported.
+	 * @return mixed The return value of the `deliver` function.
+	 */
+	public function deliver($message, array $options = array()) {
+		$config = $this->_config;
+		$headers = $message->headers;
+		foreach ($this->_message_addresses as $property => $header) {
+			if (is_int($property)) {
+				$property = $header;
+				$header = ucfirst($property);
+			}
+			$headers[$header] = $this->address($message->$property);
+		}
+		$headers['Date'] = date('r', $message->date);
+		$headers['MIME-Version'] = "1.0";
+
+		$types = $message->types();
+		$attachments = $message->attachments();
+		$charset = $message->charset;
+		if (count($types) == 1 && count($attachments) == 0) {
+			$type = key($types);
+			$content_type = current($types);
+			$headers['Content-Type'] = "{$content_type};charset=\"{$charset}\"";
+			$body = wordwrap($message->body($type), 70);
+		} else {
+			$boundary = uniqid('LI3_MAILER_SIMPLE_');
+			$headers['Content-Type'] = "multipart/alternative;boundary=\"{$boundary}\"";
+			$body = "This is a multi-part message in MIME format.\n\n";
+			foreach ($types as $type => $content_type) {
+				$body .= "--{$boundary}\n";
+				$body .= "Content-Type: {$content_type};charset=\"{$charset}\"\n\n";
+				$body .= wordwrap($message->body($type), 70) . "\n";
+			}
+			foreach ($attachments as $attachment) {
+				if (isset($attachment['path'])) {
+					if ($attachment['path'][0] == '/' && !is_readable($attachment['path'])) {
+						$content = false;
+					} else {
+						$content = file_get_contents($attachment['path']);
+					}
+					if ($content === false) {
+						throw new RuntimeException("Can not attach path `{$attachment['path']}`.");
+					}
+				} else {
+					$content = $attachment['data'];
+				}
+				$body .= "--{$boundary}\n";
+				$filename = isset($attachment['filename']) ? $attachment['filename'] : null;
+				if (isset($attachment['content-type'])) {
+					$content_type = $attachment['content-type'];
+					if ($filename && !preg_match('/;\s+name=/', $content_type)) {
+						$content_type .= "; name=\"{$filename}\"";
+					}
+					$body .= "Content-Type: {$content_type}\n";
+				}
+				if (isset($attachment['disposition'])) {
+					$disposition = $attachment['disposition'];
+					if ($filename && !preg_match('/;\s+filename=/', $disposition)) {
+						$disposition .= "; filename=\"{$filename}\"";
+					}
+					$body .= "Content-Disposition: {$disposition}\n";
+				}
+				if (isset($attachment['id'])) {
+					$body .= "Content-ID: <{$attachment['id']}>\n";
+				}
+				$body .= "\n" . wordwrap($content, 70) . "\n";
+			}
+			$body .= "--{$boundary}--";
+		}
+
+		$headers = join("\r\n", array_map(function($name, $value) {
+			return "{$name}: {$value}";
+		}, array_keys($headers), $headers));
+		$to = $this->address($message->to);
+
+		// Setup and execute via CURL extension
+		$ch = curl_init($config['url']);
+		curl_setopt($ch, CURLOPT_POST, 1);
+		curl_setopt($ch, CURLOPT_USERPWD, $config['key']);
+		$data = array(
+			'from' => $message->from,
+			'to' => $to,
+			//'o:campaign' => '860s', // ADD THIS FOR A CAMPAIGN
+			'subject' => $message->subject,
+			//'text' => $body, // USE THIS FOR TEXT ONLY EMAIL
+			'html' => $body // USE THIS FOR HTML EMAIL
+		);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+		curl_exec($ch);
+		curl_close($ch);
+	}
+	
+	/**
+	 * Debugging helper to test headers, by wrapping output in a
+	 * nice purdy white background and so on.
+	 * 
+	 * @param object What you want to see
+	*/
+	function debug( $thingy ){
+		echo '<div class="span9 well" style="margin-left:0;"><pre>';
+		print_r( $thingy );
+		echo '</pre></div>';
+		exit;
+	}
+}
+
+?>

--- a/net/mail/transport/adapter/Mailgun.php
+++ b/net/mail/transport/adapter/Mailgun.php
@@ -47,7 +47,6 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 	 * @return mixed The return value of the `deliver` function.
 	 */
 	public function deliver($message, array $options = array()) {
-		//$this->debug($message);
 		$config = $this->_config;
 		$headers = $message->headers;
 		foreach ($this->_message_addresses as $property => $header) {
@@ -147,19 +146,5 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 		curl_exec($ch);
 		curl_close($ch);
 	}
-	
-	/**
-	 * Debugging helper to test headers, by wrapping output in a
-	 * nice purdy white background and so on.
-	 * 
-	 * @param object What you want to see
-	*/
-	function debug( $thingy ){
-		echo '<div class="span9 well" style="margin-left:0;"><pre>';
-		print_r( $thingy );
-		echo '</pre></div>';
-		exit;
-	}
-}
 
 ?>

--- a/net/mail/transport/adapter/Mailgun.php
+++ b/net/mail/transport/adapter/Mailgun.php
@@ -127,10 +127,17 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 			'from' => $message->from,
 			'to' => $to,
 			//'o:campaign' => '860s', // ADD THIS FOR A CAMPAIGN
-			'subject' => $message->subject,
-			'text' => $message->body('text'), // USE THIS FOR TEXT ONLY EMAIL
-			'html' => $message->body('html') // USE THIS FOR HTML EMAIL
+			'subject' => $message->subject
 		);
+		if(isset($message->body('text'))){ 					// USE THIS FOR TEXT ONLY EMAIL
+			array_push($data,array('text' => $message->body('text')));
+		}
+		if(isset($message->body('html'))){ 			 // USE THIS FOR HTML EMAIL
+			array_push($data ,array('html' => $message->body('html')));
+		}
+		if(isset($message->campaign)){
+			array_push($data ,array('o:campaign' => $message->campaign));
+		}
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
 		curl_exec($ch);
 		curl_close($ch);

--- a/net/mail/transport/adapter/Mailgun.php
+++ b/net/mail/transport/adapter/Mailgun.php
@@ -129,14 +129,17 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 			//'o:campaign' => '860s', // ADD THIS FOR A CAMPAIGN
 			'subject' => $message->subject
 		);
+		// USE THIS FOR TEXT EMAIL
 		$text = $message->body('text');
-		if(isset($text)){ 					// USE THIS FOR TEXT ONLY EMAIL
+		if(isset($text)){
 			$data['text'] = $text;
 		}
+		// USE THIS FOR HTML EMAIL
 		$html = $message->body('html');
-		if(isset($html)){ 			 // USE THIS FOR HTML EMAIL
+		if(isset($html)){
 			$data['html'] = $html;
 		}
+		// USE THIS FOR CAMPAIGNS
 		if(isset($message->campaign)){
 			$data['o:campaign'] = $message->campaign;
 		}

--- a/net/mail/transport/adapter/Mailgun.php
+++ b/net/mail/transport/adapter/Mailgun.php
@@ -120,7 +120,7 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 		$to = $this->address($message->to);
 
 		// Setup and execute via CURL extension
-		$ch = curl_init($config['url']);
+		$ch = curl_init($config['url'] . 'messages');
 		curl_setopt($ch, CURLOPT_POST, 1);
 		curl_setopt($ch, CURLOPT_USERPWD, $config['key']);
 		$data = array(
@@ -129,14 +129,16 @@ class Mailgun extends \li3_mailer\net\mail\Transport {
 			//'o:campaign' => '860s', // ADD THIS FOR A CAMPAIGN
 			'subject' => $message->subject
 		);
-		if(isset($message->body('text'))){ 					// USE THIS FOR TEXT ONLY EMAIL
-			array_push($data,array('text' => $message->body('text')));
+		$text = $message->body('text');
+		if(isset($text)){ 					// USE THIS FOR TEXT ONLY EMAIL
+			$data['text'] = $text;
 		}
-		if(isset($message->body('html'))){ 			 // USE THIS FOR HTML EMAIL
-			array_push($data ,array('html' => $message->body('html')));
+		$html = $message->body('html');
+		if(isset($html)){ 			 // USE THIS FOR HTML EMAIL
+			$data['html'] = $html;
 		}
 		if(isset($message->campaign)){
-			array_push($data ,array('o:campaign' => $message->campaign));
+			$data['o:campaign'] = $message->campaign;
 		}
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
 		curl_exec($ch);

--- a/readme.wiki
+++ b/readme.wiki
@@ -67,6 +67,7 @@ Delivery::config(array('default' => array(
 
  - [ **Simple**](li3_mailer/net/mail/transport/adapter/Simple): sends email messages with `PHP`'s built-in function `mail`.
  - [ **Swift**](li3_mailer/net/mail/transport/adapter/Swift): depends on the [ SwiftMailer](http://swiftmailer.org/) library for sending email messages.
+ - [ **Mailgun**](li3_mailer/net/mail/transport/adapter/Mailgun): depends on the [ Mailgun](http://www.mailgun.com/) hosted service for sending email messages.
  - [ **Debug**](li3_mailer/net/mail/transport/adapter/Debug): instead of sending email messages it logs them to a given file or directory.
 
 ### Messages


### PR DESCRIPTION
First, this code was just written and documented, so feel free to refactor if you see stuff that needs to be done in a better way. Matter of fact, hit me with the changes and I'll make them for you so we can learn the Li3 Way(TM)...

Ok we got support for mailgun, also checks for html.php and text.php. We managed to hook in support for multipart messages as well, so you can send both; and we also plugged in tags so you can tag your messages so they are grouped in the reporting interface at Mailgun.

I can commit all our changes here and make pull requests if that's how you like to roll. Thanks for li3_mailer, hope to be more active with it in the future :-)

-- Mitch
