### PR TITLE
Added getMessage method to access Swift_Message

### DIFF
--- a/net/mail/transport/adapter/Swift.php
+++ b/net/mail/transport/adapter/Swift.php
@@ -49,6 +49,8 @@ class Swift extends \li3_mailer\net\mail\Transport {
 		)
 	);
 
+	protected $_message;
+
 	/**
 	 * Message property names for translating a `li3_mailer\net\mail\Message`
 	 * to `Swift_Message`.
@@ -89,8 +91,16 @@ class Swift extends \li3_mailer\net\mail\Transport {
 	 */
 	public function deliver($message, array $options = array()) {
 		$transport = $this->_transport($options);
-		$message = $this->_message($message);
-		return $transport->send($message);
+		$this->_message = $this->_message($message);
+		return $transport->send($this->_message);
+	}
+
+	/**
+	 * Allows read access to the SiwftMailer message object after it's
+	 * been delivered.
+	 */
+	public function getMessage() {
+		return $this->_message;
 	}
 
 	/**

--- a/net/mail/transport/adapter/Swift.php
+++ b/net/mail/transport/adapter/Swift.php
@@ -51,6 +51,8 @@ class Swift extends \li3_mailer\net\mail\Transport {
 
 	protected $_message;
 
+	protected $_messageId;
+
 	/**
 	 * Message property names for translating a `li3_mailer\net\mail\Message`
 	 * to `Swift_Message`.
@@ -91,8 +93,19 @@ class Swift extends \li3_mailer\net\mail\Transport {
 	 */
 	public function deliver($message, array $options = array()) {
 		$transport = $this->_transport($options);
+
 		$this->_message = $this->_message($message);
+		$this->_messageId = $this->_message->getId();
+
 		return $transport->send($this->_message);
+	}
+
+	/**
+	 * Allows read access to the message id after it's
+	 * been delivered.
+	 */
+	public function getMessageId() {
+		return $this->_messageId;
 	}
 
 	/**


### PR DESCRIPTION
I've added a method for read access to the Swift_Message instance. I needed it so I could reach into the transport adapter and pick out the Message-ID from the message once it had been delivered. Might be useful if there are any other headers etc to read once message has been sent.

I then was able to use the following to get what I needed from my controller once I'd delivered the message:

``` php
$message_id = null;

Mailer::applyFilter('deliver', function($self, $params, $chain) use (&$message_id) {
    extract($params);
    $result = $chain->next($self, $params, $chain);
    $message_id = $transport->getMessage()->getHeaders()->get('Message-ID')->getFieldBody();

    return $result;
});
```
